### PR TITLE
Added BBC and Reuters as sources

### DIFF
--- a/bulletin.mjs
+++ b/bulletin.mjs
@@ -29,7 +29,12 @@ export class Bulletin
             while (data === undefined);     //returns undefined if chosen article is no good, i.e. a Q&A article on the Guardian
 
             data.then(article => {      //returned in form of promise with value of article
-                article.read();
+                article.read();			//Getting common error here
+				/**
+				Uncaught (in promise) TypeError: Cannot read property 'read' of undefined
+				Can probably use try-catch but need to call for another article to be retrieved
+				More importantly, why is the article undefined?
+				*/
             })
         }
     }

--- a/bulletin.mjs
+++ b/bulletin.mjs
@@ -15,13 +15,15 @@ export class Bulletin
      */
     static fetchNews()
     {
-        for (let i=0; i<topics.length; i++)     // change i< to prevent unnecessary credits being used up
+        for (let i=0; i<Object.keys(topics).length; i++)     // change i< to prevent unnecessary credits being used up
         {
             let data;
             do
             {
                 const source = Object.keys(sources)[Math.floor(Math.random()*Object.keys(sources).length)];  //get random source to contact
-                data = PageParser.getArticle(source, topics[i], sentences);          //send source, topic and number of sentences to summarise to
+				const topic = Object.keys(topics)[i];
+				const topiclink = topics[topic][source];
+				data = PageParser.getArticle(source, topic, topiclink, sentences);          //send source, topic and number of sentences to summarise to
             }
             while (data === undefined);     //returns undefined if chosen article is no good, i.e. a Q&A article on the Guardian
 

--- a/bulletin.mjs
+++ b/bulletin.mjs
@@ -16,6 +16,7 @@ export class Bulletin
     static fetchNews()
     {
         for (let i=0; i<Object.keys(topics).length; i++)     // change i< to prevent unnecessary credits being used up
+		//for (let i=0; i<1; i++)     // change i< to prevent unnecessary credits being used up
         {
             let data;
             do

--- a/pageparser.mjs
+++ b/pageparser.mjs
@@ -18,12 +18,12 @@ export class PageParser
      * @param sentences - the number of sentences to summarise down to
      * @returns {Promise<*|Article>} - the article is contained in the promise value
      */
-    static getArticle(source, topic, sentences)
+    static getArticle(source, topic, topiclink, sentences)
     {
         if (source === "The Guardian")
-            return PageParser.extractGuardian(topic, sentences);
-        //else if (source === "BBC")
-            //return this.extractBBC(topic);
+            return PageParser.extractGuardian(topic, topiclink, sentences);
+        else if (source === "BBC")
+            return PageParser.extractBBC(topic, topiclink, sentences);
     }
 
     /**
@@ -32,15 +32,14 @@ export class PageParser
      * @param sentences - the number of sentences to summarise down to
      * @returns {Promise<undefined|Article>} - returns a constructed news article or undefined if the article is no good
      */
-    static async extractGuardian(topic, sentences)
+    static async extractGuardian(topic, topiclink, sentences)
     {
         /**
          * GETTING RANDOM LINK FOR TOPIC
          */
 
         let publisher = "The Guardian";
-
-        let linkdata = await PageParser.extractGuardianLinks(topic);
+        let linkdata = await PageParser.extractPageData(topiclink);
         linkdata = linkdata.split('<a href="' + sources[publisher] + '' + topic + '/');
 
         let linksarr = [];
@@ -48,6 +47,110 @@ export class PageParser
         {
             linksarr.push(linkdata[i].split('"')[0]);
         }
+
+        const links = Array.from(new Set(linksarr));    //array of URLs for articles
+
+        let randomlink;
+
+        do
+        {
+            randomlink = sources[publisher] + topic + '/' + links[Math.floor(Math.random()*links.length)];  //select a random article
+        }
+        while (randomlink.startsWith(sources[publisher] + topic + '/video/'));  //articles devoted to a video are no good
+
+        /**
+         * Extracting article from article page
+         */
+
+        const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
+
+        if (data.includes('<p><strong>') || data.includes('<h2><strong>'))      //indicates a Q&A article
+        {
+            return undefined;
+        }
+
+        let headline = "Random headline";
+        let text = "The topic of " + topic + " works!";
+
+        /**
+         * SUMMARISING
+         */
+
+        const smmrydata = await Summarise.summarise(randomlink, sentences);     //send article to SMMRY
+
+        if (smmrydata === undefined)    //SMMRY API unavailable
+        {
+            headline = data.split('<title>')[1].split('|')[0];      //get headline from article data
+            text = Summarise.extractText(data);                              //extract article text from article data
+        }
+        else    //SMMRY API working fine
+        {
+            headline = smmrydata['sm_api_title'];     //article headline returned
+            text = smmrydata['sm_api_content'];       //summarised article returned
+        }
+
+        if (headline === undefined || text === undefined)		//TODO or if headline contains a question mark
+        {
+            return undefined;
+        }
+
+        /**
+         * TRANSLATING
+         */
+
+        if (language_choice !== "English")
+        {
+            const publishertranslatedata = await Translator.translate(publisher, languages[language_choice]);
+            const topictranslatedata = await Translator.translate(topic, languages[language_choice]);
+            const headlinetranslatedata = await Translator.translate(headline, languages[language_choice]);
+            const texttranslatedata = await Translator.translate(text, languages[language_choice]);
+
+            //If translation API not available
+            if (publishertranslatedata === undefined || topictranslatedata === undefined || headlinetranslatedata === undefined || texttranslatedata === undefined)
+            {
+                new Speech(translation_unavailable[language_choice]).speak();
+            }
+            else if (publishertranslatedata['code'] !== 200 || topictranslatedata['code'] !== 200 || headlinetranslatedata['code'] !== 200 || texttranslatedata['code'] !== 200)
+            {
+                new Speech(translation_unavailable[language_choice]).speak();
+            }
+            else
+            {
+                publisher = publishertranslatedata['text'];
+                topic = topictranslatedata['text'];
+                headline = headlinetranslatedata['text'];
+                text = texttranslatedata['text'];
+            }
+        }
+
+        return new Article(publisher, topic, headline, randomlink, text);
+    }
+	
+	/**
+     * Queries a topic page on the BBC website and selects a random article from it
+     * @param topic - the news topic
+     * @param sentences - the number of sentences to summarise down to
+     * @returns {Promise<undefined|Article>} - returns a constructed news article or undefined if the article is no good
+     */
+    static async extractBBC(topic, topiclink, sentences)
+    {
+        /**
+         * GETTING RANDOM LINK FOR TOPIC
+         */
+
+        let publisher = "BBC";
+
+        let linkdata = await PageParser.extractPageData(topiclink);
+        linkdata = linkdata.split('href="/news/');
+
+        let linksarr = [];
+        for (let i=1; i<linkdata.length; i+=1)
+        {
+			const currentlink = linkdata[i].split('"')[0]);		//TODO parse links here. Must not contain slashes, require at least one dash, require a large integer at the end 
+            linksarr.push(currentlink);
+        }
+		
+		return new Article(publisher, topic, "This headline works", "hi there", "This is an empty article");
 
         const links = Array.from(new Set(linksarr));    //array of URLs for articles
 
@@ -135,15 +238,5 @@ export class PageParser
     static extractPageData(theurl)
     {
         return $.ajax({url: theurl}).done(function(data){}).fail(function(ajaxError){});    //not convinced this actually returns or throws an error
-    }
-
-    /**
-     * Extracts data from Guardian topic page
-     * @param topic - the news topic to focus on
-     * @returns {*} - actually returns the page data
-     */
-    static extractGuardianLinks(topic)
-    {
-        return $.ajax({ url: 'https://www.theguardian.com/' + topic + '/3019/dec/31/'}).done(function(data){}).fail(function(ajaxError){});      //same here
     }
 }

--- a/pageparser.mjs
+++ b/pageparser.mjs
@@ -141,31 +141,36 @@ export class PageParser
         let publisher = "BBC";
 
         let linkdata = await PageParser.extractPageData(topiclink);
+		linkdata = linkdata.split('<div role="region"')[0];		//Removes articles that are "featured" or unrelated to subject
         linkdata = linkdata.split('href="/news/');
 
         let linksarr = [];
         for (let i=1; i<linkdata.length; i+=1)
         {
-			const currentlink = linkdata[i].split('"')[0]);		//TODO parse links here. Must not contain slashes, require at least one dash, require a large integer at the end 
+			const currentlink = linkdata[i].split('"')[0];		
             linksarr.push(currentlink);
         }
 		
-		return new Article(publisher, topic, "This headline works", "hi there", "This is an empty article");
+		//Parsing links we've found
+		let articlelinks = [];
+		for (let i=0; i<linksarr.length; i+=1)
+		{
+			const current = linksarr[i];
+			if (!current.includes('/') && current.includes('-') && !isNaN(current[current.length-1]))
+			{
+				articlelinks.push(sources[publisher] + 'news/' + current);
+			}
+		}
 
-        const links = Array.from(new Set(linksarr));    //array of URLs for articles
+        const links = Array.from(new Set(articlelinks));    //array of URLs for articles
 
-        let randomlink;
-
-        do
-        {
-            randomlink = sources[publisher] + topic + '/' + links[Math.floor(Math.random()*links.length)];  //select a random article
-        }
-        while (randomlink.startsWith(sources[publisher] + topic + '/video/'));  //articles devoted to a video are no good
+        const randomlink = links[Math.floor(Math.random()*links.length)];  //select a random article
 
         /**
          * Extracting article from article page
          */
 
+		//TODO predict if headline is a Q&A article
         const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
 
         if (data.includes('<p><strong>') || data.includes('<h2><strong>'))      //indicates a Q&A article

--- a/pageparser.mjs
+++ b/pageparser.mjs
@@ -73,13 +73,15 @@ export class PageParser
 
         const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
 
-        if (data.includes('<p><strong>') || data.includes('<h2><strong>'))      //indicates a Q&A article
+        if (data.includes('<p><strong>') || data.includes('<h2>'))      //indicates a Q&A article
         {
             return undefined;
         }
 
         let headline = "Random headline";
         let text = "The topic of " + topic + " works!";
+        text = Summarise.extractGuardianText(data);  
+		console.log("Link is " + randomlink);
 
         /**
          * SUMMARISING
@@ -181,7 +183,7 @@ export class PageParser
 
         const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
 
-        if (data.includes('<p><strong>') || data.includes('<h2><strong>'))      //indicates a Q&A article
+        if (data.includes('<p><strong>') || data.includes('<h2>'))      //indicates a Q&A article
         {
             return undefined;
         }
@@ -291,13 +293,26 @@ export class PageParser
 
         const links = Array.from(new Set(articlelinks));    //array of URLs for articles
 
-        const randomlink = links[Math.floor(Math.random()*links.length)];  //select a random article
+        let randomlink = links[Math.floor(Math.random()*links.length)];  //select a random article
 
         /**
          * Extracting article from article page
          */
 
-        const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
+        let data = await PageParser.extractPageData(randomlink);  //fetch data from article page
+		let timeout = 0;
+		
+		while (data === undefined && timeout < 3)		//sometimes Reuters article exists on www.reuters and not uk.reuters or vice versa. Currently, just choose a different article
+		{
+			randomlink = links[Math.floor(Math.random()*links.length)];  //select a random article
+			data = await PageParser.extractPageData(randomlink);  //fetch data from article page
+			timeout += 1;
+			
+			if (data === undefined && timeout === 3)
+			{
+				return undefined;
+			}
+		}
 
         if (data.includes('<h3'))      //indicates a Q&A article
         {

--- a/pageparser.mjs
+++ b/pageparser.mjs
@@ -81,7 +81,7 @@ export class PageParser
         if (smmrydata === undefined)    //SMMRY API unavailable
         {
             headline = data.split('<title>')[1].split('|')[0];      //get headline from article data
-            text = Summarise.extractText(data);                              //extract article text from article data
+            text = Summarise.extractGuardianText(data);                              //extract article text from article data
         }
         else    //SMMRY API working fine
         {
@@ -89,7 +89,7 @@ export class PageParser
             text = smmrydata['sm_api_content'];       //summarised article returned
         }
 
-        if (headline === undefined || text === undefined)		//TODO or if headline contains a question mark
+        if (headline === undefined || text === undefined || headline.includes('?'))
         {
             return undefined;
         }
@@ -170,7 +170,6 @@ export class PageParser
          * Extracting article from article page
          */
 
-		//TODO predict if headline is a Q&A article
         const data = await PageParser.extractPageData(randomlink);  //fetch data from article page
 
         if (data.includes('<p><strong>') || data.includes('<h2><strong>'))      //indicates a Q&A article
@@ -189,8 +188,8 @@ export class PageParser
 
         if (smmrydata === undefined)    //SMMRY API unavailable
         {
-            headline = data.split('<title>')[1].split('|')[0];      //get headline from article data
-            text = Summarise.extractText(data);                              //extract article text from article data
+            headline = data.split('<title>')[1].split('- BBC News')[0];      //get headline from article data
+            text = Summarise.extractBBCText(data);                              //extract article text from article data
         }
         else    //SMMRY API working fine
         {
@@ -198,7 +197,7 @@ export class PageParser
             text = smmrydata['sm_api_content'];       //summarised article returned
         }
 
-        if (headline === undefined || text === undefined)
+        if (headline === undefined || text === undefined || headline.includes('?'))		//not sure this includes statement works
         {
             return undefined;
         }

--- a/preferences.js
+++ b/preferences.js
@@ -9,45 +9,55 @@ export let languagesdropdown = Object.keys(languages);
 
 export let sources = {
     "The Guardian": "https://www.theguardian.com/",
-	"BBC": "https://www.bbc.com/"
+	"BBC": "https://www.bbc.com/",
+	"Reuters": "https://www.reuters.com/"
 };
 
 export let topics = {
 	"sport": {
 		"The Guardian": 'https://www.theguardian.com/sport/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/sport/'
+		"BBC": 'https://www.bbc.com/sport/',
+		"Reuters": "https://www.reuters.com/news/sports/"
 		},
     "politics": {
 		"The Guardian": 'https://www.theguardian.com/politics/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/politics/'
+		"BBC": 'https://www.bbc.com/news/politics/',
+		"Reuters": "https://www.reuters.com/politics/"
 		},
     "uk": {
 		"The Guardian": 'https://www.theguardian.com/uk-news/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/uk/'
+		"BBC": 'https://www.bbc.com/news/uk/',
+		"Reuters": "https://uk.reuters.com/news/uk"
 		},
     "science": {
 		"The Guardian": 'https://www.theguardian.com/science/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/science_and_environment/'
+		"BBC": 'https://www.bbc.com/news/science_and_environment/',
+		"Reuters": "https://www.reuters.com/news/science/"
 		},
     "technology": {
 		"The Guardian": 'https://www.theguardian.com/technology/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/technology/'
+		"BBC": 'https://www.bbc.com/news/technology/',
+		"Reuters": "https://www.reuters.com/news/technology/"
 		},
     "environment": {
 		"The Guardian": 'https://www.theguardian.com/environment/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/science_and_environment/'
+		"BBC": 'https://www.bbc.com/news/science_and_environment/',
+		"Reuters": "https://uk.reuters.com/news/environment/"
 		},
     "society": {
 		"The Guardian": 'https://www.theguardian.com/society/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/education/'
+		"BBC": 'https://www.bbc.com/news/education/',
+		"Reuters": "https://www.reuters.com/news/lifestyle/"
 		},
     "business": {
 		"The Guardian": 'https://www.theguardian.com/business/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/business/'
+		"BBC": 'https://www.bbc.com/news/business/',
+		"Reuters": "https://www.reuters.com/finance/"
 		},
     "world": {
 		"The Guardian": 'https://www.theguardian.com/world/3019/dec/31/', 
-		"BBC": 'https://www.bbc.com/news/world/'
+		"BBC": 'https://www.bbc.com/news/world/',
+		"Reuters": "https://www.reuters.com/news/world/"
 		}
 };
 

--- a/preferences.js
+++ b/preferences.js
@@ -27,7 +27,7 @@ export let topics = {
     "uk": {
 		"The Guardian": 'https://www.theguardian.com/uk-news/3019/dec/31/', 
 		"BBC": 'https://www.bbc.com/news/uk/',
-		"Reuters": "https://uk.reuters.com/news/uk"
+		"Reuters": "https://uk.reuters.com/news/uk/"
 		},
     "science": {
 		"The Guardian": 'https://www.theguardian.com/science/3019/dec/31/', 

--- a/preferences.js
+++ b/preferences.js
@@ -8,20 +8,48 @@ import {languages} from "./language_config.js";
 export let languagesdropdown = Object.keys(languages);
 
 export let sources = {
-    "The Guardian": "https://www.theguardian.com/"
+    "The Guardian": "https://www.theguardian.com/",
+	"BBC": "https://www.bbc.com/news/"
 };
 
-export let topics = [
-    "sport",
-    "politics",
-    "uk-news",
-    "science",
-    "technology",
-    "environment",
-    "society",
-    "business",
-    "world"
-];
+export let topics = {
+	"sport": {
+		"The Guardian": 'https://www.theguardian.com/sport/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/sport/'
+		},
+    "politics": {
+		"The Guardian": 'https://www.theguardian.com/politics/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/politics/'
+		},
+    "uk": {
+		"The Guardian": 'https://www.theguardian.com/uk-news/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/uk/'
+		},
+    "science": {
+		"The Guardian": 'https://www.theguardian.com/science/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/science_and_environment/'
+		},
+    "technology": {
+		"The Guardian": 'https://www.theguardian.com/technology/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/technology/'
+		},
+    "environment": {
+		"The Guardian": 'https://www.theguardian.com/environment/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/science_and_environment/'
+		},
+    "society": {
+		"The Guardian": 'https://www.theguardian.com/society/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/education/'
+		},
+    "business": {
+		"The Guardian": 'https://www.theguardian.com/business/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/business/'
+		},
+    "world": {
+		"The Guardian": 'https://www.theguardian.com/world/3019/dec/31/', 
+		"BBC": 'https://www.bbc.com/news/world/'
+		}
+};
 
 /**
  * User preferences for speech and article size

--- a/preferences.js
+++ b/preferences.js
@@ -9,7 +9,7 @@ export let languagesdropdown = Object.keys(languages);
 
 export let sources = {
     "The Guardian": "https://www.theguardian.com/",
-	"BBC": "https://www.bbc.com/news/"
+	"BBC": "https://www.bbc.com/"
 };
 
 export let topics = {
@@ -54,7 +54,7 @@ export let topics = {
 /**
  * User preferences for speech and article size
  */
-export let sentences = 4;
+export let sentences = 3;
 export let language_choice = "English";
 export let pitch = 1;
 export let volume = 1;

--- a/summarise.mjs
+++ b/summarise.mjs
@@ -60,6 +60,10 @@ export class Summarise
         }
 		
 		data = data.split('<div class="content__article-body from-content-api js-article__body" itemprop="articleBody" data-test-id="article-review-body">')[1];
+		if (data === undefined)
+		{
+			return undefined;
+		}
 		
 		/**data = data.replace(/<figcaption [^|]+<\/figcaption>/g, '');    //removes caption under article image
         data = data.replace(/<figure [^|]+<\/figure>/g, '');
@@ -71,14 +75,19 @@ export class Summarise
 		let counter = 2;
 
 		while (counter < data.length-3)
-		{		
-			if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
+		{
+			const startoftext = data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<';
+			const endoftext = data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>';
+			//const startoflink = data[counter] === '<' && data[counter+1] === 'a';
+			//const endoflink = data[counter] === '>' && data[counter-1] === 'a' && data[counter-2] === '/' && data[counter-3] === '<';
+
+			if (startoftext) // || endoflink
 			{
 				articletext += " ";
 				counter += 1;
 				copy = true;
 			}
-			else if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>')
+			else if (endoftext) // || startoflink
 			{
 				copy = false;
 			}
@@ -135,7 +144,7 @@ export class Summarise
         articletext = articletext.split(/[\.\!]+(?!\d)\s*|\n+\s).join('. ');  //split by '.' but ignoring decimal numbers
         //articletext = articletext.slice(0, -1);     //removes a final quote that sometimes appears. Doesn't affect text without the quote.
 		*/
-		console.log("Text is " + articletext);
+
         return articletext;
     }
 	
@@ -147,6 +156,10 @@ export class Summarise
     static extractBBCText(data)
     {		
 		data = data.split('<p class="story-body__introduction">')[1];
+		if (data === undefined)
+		{
+			return undefined;
+		}
 		
 		let copy = true;
 		let articletext = "";
@@ -157,16 +170,21 @@ export class Summarise
 		while union bosses <a href="https://www.google.com" class="example_class">are unhappy with the outcome</a> they still need to address
 		*/
 		while (counter < data.length-3)
-		{			
-			if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p')
-			{
-				copy = false;
-			}
-			else if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
+		{
+			const startoftext = data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<';
+			const endoftext = data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>';
+			//const startoflink = data[counter] === '<' && data[counter+1] === 'a';
+			//const endoflink = data[counter] === '>' && data[counter-1] === 'a' && data[counter-2] === '/' && data[counter-3] === '<';
+
+			if (startoftext) // || endoflink
 			{
 				articletext += " ";
 				counter += 1;
 				copy = true;
+			}
+			else if (endoftext) // || startoflink
+			{
+				copy = false;
 			}
 			
 			if (copy)
@@ -186,24 +204,26 @@ export class Summarise
      * @returns {string|undefined} - the string of the article text, undefined if not available
      */
     static extractReutersText(data)
-    {	
+    {
 		let copy = false;
 		let articletext = "";
 		let counter = 2;
 
 		while (counter < data.length-3)
-		{		
-			if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
+		{
+			const startoftext = data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<';
+			const endoftext = data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>';
+
+			if (startoftext)
 			{
-				//articletext += " ";
 				counter += 1;
 				copy = true;
 			}
-			else if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>')
+			else if (endoftext)
 			{
 				copy = false;
 			}
-			
+
 			if (copy)
 			{
 				articletext += data[counter];
@@ -223,15 +243,5 @@ export class Summarise
 		articletext = articletext.split(' - ')[1];
 
         return articletext;
-    }
-
-	/**
-     * Queries SMMRY and returns JSON data
-     * @param url - the GET request to SMMRY
-     * @returns {*} - actually returns the JSON response from SMMRY
-     */
-    static contactsmmry(url)
-    {
-        return $.ajax({ url: url}).done(function(data){}).fail(function(ajaxError){});      //same here
     }
 }

--- a/summarise.mjs
+++ b/summarise.mjs
@@ -129,4 +129,61 @@ export class Summarise
 
         return articletext;
     }
+
+    /**
+     * Backup function to extract BBC article text ourselves due to SMMRY not being available
+     * @param data - the data from the article page
+     * @returns {string|undefined} - the string of the article text, undefined if not available
+     */
+    static extractReutersText(data)
+    {
+		data = data.split('<div class="StandardArticleBody_body">')[1];
+		/**
+		Could instead split at the start of the article where it mention the place of publishing and the publisher, e.g.
+		TURIN, Italy (Reuters) - Cristiano Ronaldo scored a second-half hat-trick
+		Could split at the dash that always appears.
+		*/
+		
+		let copy = true;
+		let articletext = "";
+		let counter = 0;
+
+		/**
+		This still needs to deal with links leftover in the text. They take the following form:
+		while union bosses <a href="https://www.google.com" class="example_class">are unhappy with the outcome</a> they still need to address
+		*/
+		while (counter < data.length-3)
+		{			
+			if (data[counter] == '<' && data[counter+1] == '/' && data[counter+2] == 'p')
+			{
+				copy = false;
+			}
+			else if (data[counter] == '>' && data[counter-1] == 'p' && data[counter-2] == '<')
+			{
+				articletext += " ";
+				counter += 1;
+				copy = true;
+			}
+			
+			if (copy)
+			{
+				articletext += data[counter];
+			}
+			
+			counter += 1;
+		}
+
+		//console.log("Text is " + articletext);
+        return articletext;
+    }
+
+	/**
+     * Queries SMMRY and returns JSON data
+     * @param url - the GET request to SMMRY
+     * @returns {*} - actually returns the JSON response from SMMRY
+     */
+    static contactsmmry(url)
+    {
+        return $.ajax({ url: url}).done(function(data){}).fail(function(ajaxError){});      //same here
+    }
 }

--- a/summarise.mjs
+++ b/summarise.mjs
@@ -48,11 +48,11 @@ export class Summarise
     }
 
     /**
-     * Backup function to extract article text ourselves due to SMMRY not being available
+     * Backup function to extract Guardian article text ourselves due to SMMRY not being available
      * @param data - the data from the article page
      * @returns {string|undefined} - the string of the article text, undefined if not available
      */
-    static extractText(data)
+    static extractGuardianText(data)
     {
         if (data.includes('<p><strong>') || data.includes('<h2><strong>'))
         {
@@ -85,6 +85,47 @@ export class Summarise
         articletext = articletext.split('Topics')[0];
         articletext = articletext.split(/[\.\!]+(?!\d)\s*|\n+\s*/).join('. ');  //split by '.' but ignoring decimal numbers
         articletext = articletext.slice(0, -1);     //removes a final quote that sometimes appears. Doesn't affect text without the quote.
+
+        return articletext;
+    }
+	
+	/**
+     * Backup function to extract BBC article text ourselves due to SMMRY not being available
+     * @param data - the data from the article page
+     * @returns {string|undefined} - the string of the article text, undefined if not available
+     */
+    static extractBBCText(data)
+    {		
+		data = data.split('<p class="story-body__introduction">')[1];
+		
+		let copy = true;
+		let articletext = "";
+		let counter = 0;
+
+		/**
+		This still needs to deal with links leftover in the text. They take the following form:
+		while union bosses <a href="https://www.google.com" class="example_class">are unhappy with the outcome</a> they still need to address
+		*/
+		while (counter < data.length-3)
+		{			
+			if (data[counter] == '<' && data[counter+1] == '/' && data[counter+2] == 'p')
+			{
+				copy = false;
+			}
+			else if (data[counter] == '>' && data[counter-1] == 'p' && data[counter-2] == '<')
+			{
+				articletext += " ";
+				counter += 1;
+				copy = true;
+			}
+			
+			if (copy)
+			{
+				articletext += data[counter];
+			}
+			
+			counter += 1;
+		}
 
         return articletext;
     }

--- a/summarise.mjs
+++ b/summarise.mjs
@@ -54,12 +54,60 @@ export class Summarise
      */
     static extractGuardianText(data)
     {
-        if (data.includes('<p><strong>') || data.includes('<h2><strong>'))
+		if (data.includes('<p><strong>') || data.includes('<h2>'))
+        {
+            return undefined;
+        }
+		
+		data = data.split('<div class="content__article-body from-content-api js-article__body" itemprop="articleBody" data-test-id="article-review-body">')[1];
+		
+		/**data = data.replace(/<figcaption [^|]+<\/figcaption>/g, '');    //removes caption under article image
+        data = data.replace(/<figure [^|]+<\/figure>/g, '');
+        data = data.replace(/<twitter-widget [^|]+<\/twitter-widget>/g, '');
+        data = data.replace(/<em>[^|]+<\/em>/g, '');    //removes italicised text not directly related to article*/
+		
+		let copy = false;
+		let articletext = "";
+		let counter = 2;
+
+		while (counter < data.length-3)
+		{		
+			if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
+			{
+				articletext += " ";
+				counter += 1;
+				copy = true;
+			}
+			else if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>')
+			{
+				copy = false;
+			}
+			
+			if (copy)
+			{
+				articletext += data[counter];
+			}
+			
+			counter += 1;
+		}
+
+		articletext = articletext.replace(/<\/a>/g, '');
+		//articletext = articletext.replace(/<a href=".+">/g, '');	This line here is really fucking me up. It behaves differently every time.
+		//Sometimes, it deletes all text up to another later link. Sometimes it just replaces the following text with a space. Who fucking knows.
+		articletext = articletext.replace(/<span.*>/g, '');
+		articletext = articletext.replace(/<\/span>/g, '');				
+		
+		
+		
+		
+		
+		
+        /**if (data.includes('<p><strong>') || data.includes('<h2><strong>'))
         {
             return undefined;
         }
 
-        /** Remove unneccesary things from article page */
+        /** Remove unneccesary things from article page 
         data = data.replace(/<figcaption [^|]+<\/figcaption>/g, '');    //removes caption under article image
         data = data.replace(/<figure [^|]+<\/figure>/g, '');
         data = data.replace(/<twitter-widget [^|]+<\/twitter-widget>/g, '');
@@ -72,7 +120,7 @@ export class Summarise
          */
         //data = data.replace(/<aside [^|]+<\/aside>/g, '');
         //data = data.replace('<aside .*?</aside>', '');
-
+/**
         for (let i=0; i<3; i++)
         {
             data = data.split('<aside ')[0] + data.split('</aside>')[1];
@@ -83,9 +131,11 @@ export class Summarise
         articletext = articletext.replace(/\r?\n|\r/g, "");
         articletext = articletext.split('undefined')[0];
         articletext = articletext.split('Topics')[0];
-        articletext = articletext.split(/[\.\!]+(?!\d)\s*|\n+\s*/).join('. ');  //split by '.' but ignoring decimal numbers
-        articletext = articletext.slice(0, -1);     //removes a final quote that sometimes appears. Doesn't affect text without the quote.
-
+		
+        articletext = articletext.split(/[\.\!]+(?!\d)\s*|\n+\s).join('. ');  //split by '.' but ignoring decimal numbers
+        //articletext = articletext.slice(0, -1);     //removes a final quote that sometimes appears. Doesn't affect text without the quote.
+		*/
+		console.log("Text is " + articletext);
         return articletext;
     }
 	
@@ -108,11 +158,11 @@ export class Summarise
 		*/
 		while (counter < data.length-3)
 		{			
-			if (data[counter] == '<' && data[counter+1] == '/' && data[counter+2] == 'p')
+			if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p')
 			{
 				copy = false;
 			}
-			else if (data[counter] == '>' && data[counter-1] == 'p' && data[counter-2] == '<')
+			else if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
 			{
 				articletext += " ";
 				counter += 1;
@@ -136,33 +186,22 @@ export class Summarise
      * @returns {string|undefined} - the string of the article text, undefined if not available
      */
     static extractReutersText(data)
-    {
-		data = data.split('<div class="StandardArticleBody_body">')[1];
-		/**
-		Could instead split at the start of the article where it mention the place of publishing and the publisher, e.g.
-		TURIN, Italy (Reuters) - Cristiano Ronaldo scored a second-half hat-trick
-		Could split at the dash that always appears.
-		*/
-		
-		let copy = true;
+    {	
+		let copy = false;
 		let articletext = "";
-		let counter = 0;
+		let counter = 2;
 
-		/**
-		This still needs to deal with links leftover in the text. They take the following form:
-		while union bosses <a href="https://www.google.com" class="example_class">are unhappy with the outcome</a> they still need to address
-		*/
 		while (counter < data.length-3)
-		{			
-			if (data[counter] == '<' && data[counter+1] == '/' && data[counter+2] == 'p')
+		{		
+			if (data[counter] === '>' && data[counter-1] === 'p' && data[counter-2] === '<')
 			{
-				copy = false;
-			}
-			else if (data[counter] == '>' && data[counter-1] == 'p' && data[counter-2] == '<')
-			{
-				articletext += " ";
+				//articletext += " ";
 				counter += 1;
 				copy = true;
+			}
+			else if (data[counter] === '<' && data[counter+1] === '/' && data[counter+2] === 'p' && data[counter+3] === '>')
+			{
+				copy = false;
 			}
 			
 			if (copy)
@@ -173,7 +212,16 @@ export class Summarise
 			counter += 1;
 		}
 
-		//console.log("Text is " + articletext);
+		articletext = articletext.replace(/\&rsquo\;/g, "'");
+		articletext = articletext.replace(/\&lsquo\;/g, "'");
+		articletext = articletext.replace(/\&ldquo\;/g, '"');
+		articletext = articletext.replace(/\&rdquo\;/g, '"');
+		articletext = articletext.replace(/<span.+>/g, '');
+		articletext = articletext.replace(/<\/span>/g, '');		
+		articletext = articletext.replace(/<a.+>/g, '');
+		articletext = articletext.replace(/<\/a>/g, '');
+		articletext = articletext.split(' - ')[1];
+
         return articletext;
     }
 


### PR DESCRIPTION
This PR adds the BBC and Reuters as news sources. Their articles are SMMRY-compliant and the manual extraction of the article text is mostly done but needs some work (this also partially broke the Guardian article text extraction). Not a big deal right now but needs addressing.