### PR TITLE
Fixed bug in abbreviations NOT being concatenated in articles

### DIFF
--- a/dist/js/article.js
+++ b/dist/js/article.js
@@ -58,14 +58,14 @@ var Article = /*#__PURE__*/function () {
       if (this.language === "English") {
         var headline = _pageparser.DataParser.abbreviationConcatenation(this.allheadline);
 
-        headline = this.allheadline.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
+        headline = headline.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
         if (headline) for (var i = 0; i < headline.length; i++) {
           new _speech.Speech(headline[i], this.language).speak();
         } else new _speech.Speech(this.allheadline, this.language).speak();
 
         var text = _pageparser.DataParser.abbreviationConcatenation(this.alltext);
 
-        text = this.alltext.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
+        text = text.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
         if (text) for (var _i = 0; _i < this.sentences; _i++) {
           new _speech.Speech(text[_i], this.language).speak();
         } else new _speech.Speech(this.alltext, this.language).speak();

--- a/src/js/article.mjs
+++ b/src/js/article.mjs
@@ -40,7 +40,7 @@ export class Article
         if (this.language === "English")
         {
             let headline = DataParser.abbreviationConcatenation(this.allheadline);
-            headline = this.allheadline.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
+            headline = headline.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
             if (headline)
                 for (let i=0; i<headline.length; i++)
                 {
@@ -50,7 +50,7 @@ export class Article
                 new Speech(this.allheadline, this.language).speak();
 
             let text = DataParser.abbreviationConcatenation(this.alltext);
-            text = this.alltext.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
+            text = text.replace(/([.?!])\s*(?=[A-Za-z])/g, "$1|").split("|");
             if (text)
                 for (let i=0; i<this.sentences; i++)
                 {


### PR DESCRIPTION
This is why you should listen to your IDE, kids. Articles were fetching the correct text and then overwriting it with the original text separated into sentences. Should be fixed now.